### PR TITLE
add cross testing for manylinux supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,34 @@ jobs:
           command: test
           args: --no-fail-fast
 
+  cross_testing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          aarch64-unknown-linux-gnu,
+          s390x-unknown-linux-gnu,
+          powerpc64le-unknown-linux-gnu
+        ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --no-fail-fast -- --test-threads 1
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --no-fail-fast -- --test-threads 1
+          args: --target ${{ matrix.target }} --no-fail-fast -- --test-threads 1
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
       matrix:
         target: [
           aarch64-unknown-linux-gnu,
-          s390x-unknown-linux-gnu,
           powerpc64le-unknown-linux-gnu
         ]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+**/target
 Cargo.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = bitmagic-sys/BitMagic
 	url = https://github.com/luizirber/BitMagic.git
 	commit = 663b1ae4d1068490ef5f600cf23a258bb1775c63
+	branch = more_platforms

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "bitmagic-sys/BitMagic"]
 	path = bitmagic-sys/BitMagic
-	url = https://github.com/tlk00/BitMagic.git
-	commit = 3234c22a09698181f5fe658bee02ddb6b4333306
+	url = https://github.com/luizirber/BitMagic.git
+	commit = 663b1ae4d1068490ef5f600cf23a258bb1775c63

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "bitmagic-sys/BitMagic"]
 	path = bitmagic-sys/BitMagic
 	url = https://github.com/luizirber/BitMagic.git
-	commit = 663b1ae4d1068490ef5f600cf23a258bb1775c63
 	branch = more_platforms

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "bitmagic-sys/BitMagic"]
 	path = bitmagic-sys/BitMagic
-	url = https://github.com/luizirber/BitMagic.git
-	branch = more_platforms
+	url = https://github.com/tlk00/BitMagic.git
+	commit = 3a60ef11f0324dd8dbef42321393fd69b7e22024
+	branch = master

--- a/bitmagic-sys/build.rs
+++ b/bitmagic-sys/build.rs
@@ -17,6 +17,7 @@ fn main() {
         .flag_if_supported("-std=c++14")
         .file("BitMagic/lang-maps/libbm/src/libbm.cpp")
         //.define("BM64ADDR", "1")
+        .define("BM_SIMD_NO", "1")
         .define("BM_NO_STL", "1");
 
     config.compile("bm");

--- a/bitmagic-sys/build.rs
+++ b/bitmagic-sys/build.rs
@@ -13,6 +13,7 @@ fn main() {
     config
         .cpp(true) // Switch to C++ library compilation.
         .include("BitMagic/lang-maps/libbm/include")
+        .include("BitMagic/lang-maps/libbm/src")
         .include("BitMagic/src")
         .flag_if_supported("-std=c++14")
         .file("BitMagic/lang-maps/libbm/src/libbm.cpp")

--- a/bitmagic-sys/build.rs
+++ b/bitmagic-sys/build.rs
@@ -14,6 +14,7 @@ fn main() {
         .cpp(true) // Switch to C++ library compilation.
         .include("BitMagic/lang-maps/libbm/include")
         .include("BitMagic/src")
+        .flag_if_supported("-std=c++14")
         .file("BitMagic/lang-maps/libbm/src/libbm.cpp")
         //.define("BM64ADDR", "1")
         .define("BM_NO_STL", "1");

--- a/bitmagic-sys/src/lib.rs
+++ b/bitmagic-sys/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 #![allow(improper_ctypes)]
 #![allow(clippy::redundant_static_lifetimes)]
+#![allow(clippy::upper_case_acronyms)]
 
 #[cfg(feature = "bindgen")]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ impl BVector {
         unsafe {
             res = bitmagic_sys::BM_bvector_serialize(
                 self.handle,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr() as *mut ::std::os::raw::c_char,
                 buf.len(),
                 &mut blob_size,
             );
@@ -81,7 +81,7 @@ impl BVector {
         unsafe {
             res = bitmagic_sys::BM_bvector_deserialize(
                 bnew.handle,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_ptr() as *const ::std::os::raw::c_char,
                 buf.len(),
             );
         }


### PR DESCRIPTION
Compilation of https://github.com/dib-lab/sourmash/pull/1221 broke because bitmagic was not being tested on manylinux-supported platforms (aarch64, s390x, ppc64le). Adding tests here to avoid breakage of downstream users.