### PR TITLE
Use cc instead of cmake for compiling bitmagic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           LLVM_CONFIG_PATH: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}/bin/llvm-config
         with:
           command: test
-          args: --no-fail-fast -- --test-threads 1
+          args: --no-fail-fast --release -- --test-threads 1
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           LLVM_CONFIG_PATH: ${{ runner.temp }}/llvm-${{ matrix.clang[0] }}/bin/llvm-config
         with:
           command: test
-          args: --no-fail-fast --release -- --test-threads 1
+          args: --no-fail-fast
 
   coverage:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmagic"
-version = "0.1.2+bitmagic.7.3.1"
+version = "0.2.0+bitmagic.7.3.1"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 edition = "2018"
 
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/luizirber/bitmagic-rs"
 
 [dependencies]
-bitmagic-sys = { version = "0.1.1", path = "bitmagic-sys" }
+bitmagic-sys = { version = "0.2.0", path = "bitmagic-sys" }
 
 [features]
 bindgen = ["bitmagic-sys/bindgen"]

--- a/bitmagic-sys/Cargo.toml
+++ b/bitmagic-sys/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 build = "build.rs"
 description = "Low-level bindings for the bitmagic."
 license = "Apache-2.0"
-#links = "bm"
+links = "bm"
 readme = "README.md"
 repository = "https://github.com/luizirber/bitmagic-rs"
 
@@ -14,4 +14,4 @@ repository = "https://github.com/luizirber/bitmagic-rs"
 
 [build-dependencies]
 bindgen = { version = "0.55.0", optional = true }
-cmake = "0.1.45"
+cc = "1.0.67"

--- a/bitmagic-sys/Cargo.toml
+++ b/bitmagic-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitmagic-sys"
-version = "0.1.1+bitmagic.7.3.1"
+version = "0.2.0+bitmagic.7.3.1"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/bitmagic-sys/build.rs
+++ b/bitmagic-sys/build.rs
@@ -1,53 +1,25 @@
-use std::env;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-
 fn main() {
     // TODO: deal with
     //   - optimization settings
     //   - wasm
 
-    let host = env::var("HOST").unwrap();
-    let target = env::var("TARGET").unwrap();
+    //let host = env::var("HOST").unwrap();
+    //let target = env::var("TARGET").unwrap();
 
-    let host_and_target_contain = |s| host.contains(s) && target.contains(s);
+    //let host_and_target_contain = |s| host.contains(s) && target.contains(s);
 
-    // patch BitMagic/lang-maps/CMakeLists.txt
-    // -- start of patching
-    let cmake_config = Path::new("BitMagic/lang-maps/CMakeLists.txt");
+    let mut config = cc::Build::new();
 
-    // Open and read the file entirely
-    let mut src = File::open(&cmake_config).unwrap();
-    let mut data = String::new();
-    src.read_to_string(&mut data).unwrap();
-    drop(src); // Close the file early
-
-    // Run the replace operation in memory
-    let new_data = data.replace("\nset(CMAKE_BINARY_DIR", "\n#set(CMAKE_BINARY_DIR");
-
-    // Recreate the file and dump the processed contents to it
-    let mut dst = File::create(&cmake_config).unwrap();
-    dst.write_all(new_data.as_bytes()).unwrap();
-    // -- end of patching
-
-    let mut config = cmake::Config::new("BitMagic/lang-maps/");
     config
-        .build_target("bm-static")
-        .define("BM_NO_STL", "1")
-        //.define("CMAKE_EXPORT_COMPILE_COMMANDS", "1")
-        //.env("CMAKE_EXPORT_COMPILE_COMMANDS", "1")
-        .very_verbose(true);
-    let dst = config.build();
+        .cpp(true) // Switch to C++ library compilation.
+        .include("BitMagic/lang-maps/libbm/include")
+        .include("BitMagic/src")
+        .file("BitMagic/lang-maps/libbm/src/libbm.cpp")
+        .define("BM_NO_STL", "1");
 
-    let mut path_dst = PathBuf::new();
-    path_dst.push(dst);
-    path_dst.push("build");
-    if host_and_target_contain("windows") && host_and_target_contain("msvc") {
-        path_dst.push(config.get_profile());
-    }
-    println!("cargo:rustc-link-search=native={}", path_dst.display());
-    println!("cargo:rustc-link-lib=static=bm-static");
+    config.compile("bm");
+
+    println!("cargo:rustc-link-lib=static=bm");
 
     generate_bindings();
 }

--- a/bitmagic-sys/build.rs
+++ b/bitmagic-sys/build.rs
@@ -15,6 +15,7 @@ fn main() {
         .include("BitMagic/lang-maps/libbm/include")
         .include("BitMagic/src")
         .file("BitMagic/lang-maps/libbm/src/libbm.cpp")
+        //.define("BM64ADDR", "1")
         .define("BM_NO_STL", "1");
 
     config.compile("bm");
@@ -34,7 +35,7 @@ fn generate_bindings() {
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("couldn't write bindings!");

--- a/src/fixedbitset_api.rs
+++ b/src/fixedbitset_api.rs
@@ -780,7 +780,6 @@ impl<T: Copy> IndexRange<T> for Range<T> {
 mod tests {
     use crate::BVector;
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn it_works() {
         const N: usize = 50;
@@ -808,7 +807,6 @@ mod tests {
         fb.clear();
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn grow() {
         let mut fb = BVector::with_capacity(48);
@@ -837,7 +835,6 @@ mod tests {
         assert!(fb.contains(3));
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn copy_bit() {
         let mut fb = BVector::with_capacity(48);
@@ -906,7 +903,6 @@ mod tests {
         assert_eq!(vec![7, 11, 12, 35, 40, 50, 77, 95, 99], ones);
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn iter_ones_range() {
         fn test_range(from: usize, to: usize, capa: usize) {
@@ -958,7 +954,6 @@ mod tests {
         assert_eq!(fb.len(), 0);
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn insert_range() {
         let mut fb = BVector::with_capacity(97);
@@ -977,7 +972,6 @@ mod tests {
         assert!(!fb.contains(128));
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn set_range() {
         let mut fb = BVector::with_capacity(48);
@@ -995,7 +989,6 @@ mod tests {
         assert!(!fb.contains(64));
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn toggle_range() {
         let mut fb = BVector::with_capacity(40);
@@ -1085,7 +1078,6 @@ mod tests {
         assert_eq!(b.len(), ab.len());
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn intersection() {
         let len = 109;
@@ -1142,7 +1134,6 @@ mod tests {
         assert_eq!(ab, a, "union and union_with produce the same results");
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn difference() {
         let a_len = 83;
@@ -1171,7 +1162,6 @@ mod tests {
         );
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn symmetric_difference() {
         let a_len = 83;
@@ -1442,7 +1432,6 @@ mod tests {
         assert!(!a.is_subset(&b) && !b.is_superset(&a));
     }
 
-    #[cfg(not(target_os = "windows"))]
     #[test]
     fn subset_superset_longer() {
         let a_len = 153;

--- a/src/fixedbitset_api.rs
+++ b/src/fixedbitset_api.rs
@@ -94,6 +94,10 @@ impl BVector {
     ///
     /// Note: Also available with index syntax: `bvector[bit]`.
     pub fn contains(&self, bit: usize) -> bool {
+        if bit >= self.len() {
+            return false;
+        }
+
         let mut pval = 0;
         let res;
         unsafe {


### PR DESCRIPTION
Using `cc` avoids needing `cmake` and other dependencies during build time. The drawback is reinventing what the original cmake configurations from BitMagic do...